### PR TITLE
お気に入り登録の際の不具合修正

### DIFF
--- a/app/Http/Controllers/RestaurantController.php
+++ b/app/Http/Controllers/RestaurantController.php
@@ -125,7 +125,7 @@ class RestaurantController extends Controller
             $restaurants = $response->json()['results']['shop'];
             $randomIndex = array_rand($restaurants);
             $randomRestaurant = $restaurants[$randomIndex];
-            session(['randomRestaurant' => $randomRestaurant]);
+            session(['saveRestaurant' => $randomRestaurant]);
             return view('restaurant_detail', [
                 'restaurant' => $randomRestaurant,
                 'keyword' => null,
@@ -150,6 +150,7 @@ class RestaurantController extends Controller
             ];
             $response = Http::get($apiEndpoint, $params);
             $restaurant = $response->json()['results']['shop'][0];
+            session(['saveRestaurant' => $restaurant]);
             return view('restaurant_detail', [
                 'restaurant' => $restaurant,
                 'keyword' => $keyword,
@@ -163,9 +164,9 @@ class RestaurantController extends Controller
     public function saved(Request $request, $restaurantId, $user_id)
     {
         Favorite::toggleFavorite($restaurantId, $user_id);
-        $randomRestaurant = session('randomRestaurant');
+        $saveRestaurant = session('saveRestaurant');
         return view('restaurant_detail', [
-            'restaurant' => $randomRestaurant,
+            'restaurant' => $saveRestaurant,
             'keyword' => null,
             'range' => 3
         ]);


### PR DESCRIPTION
## 変更点の概要

お気に入り登録の際の不具合修正

## 今回変更した点（追加した機能など）

- [x] session名をsaveRestaurantに変更
- [x] ピックアップ検索の際のみsessionが保存されていたが、他検索方法の際にも保存されるように変更

## 今回やらなかったこと（次回プルリクで行うものなど）

- なし

## この変更でできるようになること

ログイン後、レストラン保存処理を行ってもエラーが発生しない

## できなくなること

- なし

## 動作確認

- レストランの保存処理　実行

## その他・疑問点など

- なし
